### PR TITLE
chore: reduce tracing excessive noise

### DIFF
--- a/src/OpenTelemetryModuleDefaultConfig.ts
+++ b/src/OpenTelemetryModuleDefaultConfig.ts
@@ -57,6 +57,9 @@ export const OpenTelemetryModuleDefaultConfig = <OpenTelemetryModuleConfig>{
       '@opentelemetry/instrumentation-net': {
         enabled: false,
       },
+      '@opentelemetry/instrumentation-dns': {
+        enabled: false,
+      },
       '@opentelemetry/instrumentation-graphql': {
         enabled: true,
         mergeItems: true,


### PR DESCRIPTION
Disable `instrumentation-dns` and opentelemetry/instrumentation-net` autoinstrumentation as default behaviour to reduce noise